### PR TITLE
Fix build with gcc 7

### DIFF
--- a/tkmpeg.C
+++ b/tkmpeg.C
@@ -73,7 +73,7 @@ TkMPEG::TkMPEG(Tcl_Interp* intp)
  int TkMPEG::create(int argc, const char* argv[])
 {
   if (argc == 8) {
-    if (argv[2] == '\0') {
+    if (*argv[2] == '\0') {
 	Tcl_AppendResult(interp, "bad filename", NULL);
 	return TCL_ERROR;
     }
@@ -127,7 +127,7 @@ TkMPEG::TkMPEG(Tcl_Interp* intp)
 
 int TkMPEG::add(int argc, const char* argv[])
 {
-  if (argv[2] == '\0') {
+  if (*argv[2] == '\0') {
     Tcl_AppendResult(interp, "bad image name", NULL);
     return TCL_ERROR;
   }


### PR DESCRIPTION
Build fails with gcc 7 with:
```
tkmpeg.C: In member function 'int TkMPEG::create(int, const char**)':
tkmpeg.C:76:20: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
     if (argv[2] == '\0') {
                    ^~~~
tkmpeg.C: In member function 'int TkMPEG::add(int, const char**)':
tkmpeg.C:130:18: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
   if (argv[2] == '\0') {
                  ^~~~
```